### PR TITLE
talkspiritenv:10.16

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.10.0
+FROM node:10.16.0
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Update needed

apt-get for Chromium with Puppeteer may not be needed because of ChromeHeadless being used now.

New branch needed before merge!