### PR TITLE
16.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 talkSpirit Env
+
+# Version 
+
+La version [16.13-buster](https://hub.docker.com/layers/node/library/node/16.13-buster/images/sha256-af7e2f1a770d1e9a8d3199bde06490de296837644bd9b292b8f28af6e2aa504d?context=explore) correspond à la version [lts-buster](https://hub.docker.com/layers/node/library/node/16.13-buster/images/sha256-af7e2f1a770d1e9a8d3199bde06490de296837644bd9b292b8f28af6e2aa504d?context=explore) de node au 10/11/2021.
+
+L'image `talkspiritenv` est accessible avec le tag `talkspirit/talkspiritenv:16.13`

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.15.3-buster
+FROM node:16.13-buster
  
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Mise à jour de node en version 16.13 pour l'image talkspirit/talkspiritenv 

Testé : 

```
docker run --rm --name some-node16 talkspirit/talkspiritenv:16.13 bash -c 'npm version'
{
  npm: '8.1.0',
  node: '16.13.0',
  v8: '9.4.146.19-node.13',
  uv: '1.42.0',
  zlib: '1.2.11',
  brotli: '1.0.9',
  ares: '1.17.2',
  modules: '93',
  nghttp2: '1.45.1',
  napi: '8',
  llhttp: '6.0.4',
  openssl: '1.1.1l+quic',
  cldr: '39.0',
  icu: '69.1',
  tz: '2021a',
  unicode: '13.0',
  ngtcp2: '0.1.0-DEV',
  nghttp3: '0.1.0-DEV'
}
```